### PR TITLE
Keep visuals visible during regeneration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,217 @@
+import './App.css';
+import { useState } from 'react';
+import { MathProblemForm } from "@/components/forms/MathProblemForm";
+import { VisualLanguageForm } from "@/components/forms/VisualLanguageForm";
+import { VisualizationResults } from "@/components/visualization/VisualizationResults";
+
+import { GearLoading } from "@/components/ui/gear-loading";
+import { Toaster } from "@/components/ui/sonner";
+import { useAppState } from "@/hooks/useAppState";
+
+function App() {
+  const {
+    vl,
+    vlFormLoading,
+    mpFormLoading,
+    svgFormal,
+    svgIntuitive,
+    formalError,
+    intuitiveError,
+    missingSVGEntities,
+    uploadGenerating,
+    hasCompletedGeneration,
+    initialMWP,
+    initialFormula,
+    componentMappings,
+    setMpFormLoading,
+    setVLFormLoading,
+    setResults,
+    resetResults,
+    resetVisuals,
+    clearMissingSVGEntities,
+    handleRegenerateAfterUpload,
+    handleAbort,
+    saveInitialValues,
+  } = useAppState();
+  
+  // State for highlighting
+  const [dslHighlightRanges, setDslHighlightRanges] = useState<Array<[number, number]>>([]);
+  const [mwpHighlightRanges, setMwpHighlightRanges] = useState<Array<[number, number]>>([]);
+
+  // Determine if any loading is happening and what message to show
+  const isLoading = mpFormLoading || vlFormLoading || uploadGenerating;
+  const loadingMessage = mpFormLoading ? "Generating..." : "Regenerating...";
+  
+  // Handle component updates from edit panel
+  const handleComponentUpdate = (updatedDSL: string, updatedMWP: string) => {
+    // Update the visual language and initial MWP
+    saveInitialValues(updatedMWP, initialFormula);
+    // Update the DSL without clearing visuals - they'll be updated after regeneration completes
+    setResults(
+      updatedDSL,
+      svgFormal,  // Keep existing visuals visible during regeneration
+      svgIntuitive,
+      formalError,
+      intuitiveError,
+      missingSVGEntities,
+      updatedMWP,
+      initialFormula,
+      componentMappings
+    );
+    // Note: The actual regeneration would be triggered by the VisualLanguageForm
+    // when it detects the DSL change
+  };
+  
+
+  return (
+    <>
+      <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">
+        {!hasCompletedGeneration ? (
+          /* Centered layout (initial state and during loading) */
+          <div className="container mx-auto px-4 py-4 lg:px-8">
+            <div className="flex flex-col items-center justify-center min-h-[calc(100vh-2rem)]">
+              {/* Header with enhanced visual hierarchy */}
+              <div className="text-center mb-8 space-y-3">
+                <div className="flex items-center justify-center gap-3 mb-3">
+                  <div className="p-2 bg-primary/10 rounded-full">
+                    <img 
+                      src="/math2visual-logo.svg" 
+                      alt="Math2Visual Logo" 
+                      className="w-8 h-8"
+                    />
+                  </div>
+                  <h1 className="text-4xl font-bold bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent">
+                    Math2Visual
+                  </h1>
+                </div>
+                <p className="text-muted-foreground text-lg max-w-2xl mx-auto leading-relaxed">
+                  Generating Pedagogically Meaningful Visuals for Math Word Problems
+                </p>
+                <div className="w-24 h-1 bg-gradient-to-r from-primary/50 to-primary mx-auto rounded-full"></div>
+              </div>
+              
+              {/* Centered Math Problem Form with card styling */}
+              <div className="w-full max-w-3xl mb-4">
+                <div className="bg-card/50 backdrop-blur-sm border border-border/50 rounded-2xl p-6 lg:p-8 shadow-lg">
+                  <MathProblemForm 
+                    onSuccess={setResults}
+                    onLoadingChange={(loading, abortFn) => {
+                      setMpFormLoading(loading, abortFn);
+                    }}
+                    onReset={resetResults}
+                    initialMwp={initialMWP}
+                    initialFormula={initialFormula}
+                    saveInitialValues={saveInitialValues}
+                    rows={5}
+                  />
+                </div>
+              </div>
+
+              {/* Loading state with better positioning and spacing */}
+              {isLoading && (
+                <div className="animate-in fade-in-0 duration-300">
+                  <GearLoading 
+                    message={loadingMessage} 
+                    onAbort={handleAbort}
+                    showAbortButton={true}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          /* Two-column layout after generation completes */
+          <div className="container mx-auto px-4 py-4 lg:px-8">
+            <div className="grid grid-cols-1 xl:grid-cols-2 gap-8 min-h-[calc(100vh-2rem)] items-start">
+              {/* Left Panel - Title / Input Forms */}
+              <div className="flex flex-col space-y-6 xl:sticky xl:top-6 xl:h-[calc(100vh-3rem)] xl:z-10">
+                 {/* Two-column input layout */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 flex-1 min-h-0">
+                  {/* Math Problem Input Column */}
+                  <div className="space-y-6">
+                    {/* Header */}
+                    <div className="text-center">
+                      <div className="flex items-center justify-center gap-3 mb-2">
+                        <img 
+                          src="/math2visual-logo.svg" 
+                          alt="Math2Visual Logo" 
+                          className="w-8 h-8"
+                        />
+                        <h1 className="text-3xl font-bold">Math2Visual</h1>
+                      </div>
+                      <p className="text-muted-foreground text-sm">Generating Pedagogically Meaningful Visuals for Math Word Problems</p>
+                    </div>
+                    
+                    <MathProblemForm 
+                      onSuccess={setResults}
+                      onLoadingChange={(loading, abortFn) => {
+                        setMpFormLoading(loading, abortFn);
+                      }}
+                      onReset={resetResults}
+                      initialMwp={initialMWP}
+                      initialFormula={initialFormula}
+                      saveInitialValues={saveInitialValues}
+                      rows={8}
+                      highlightRanges={mwpHighlightRanges}
+                    />
+                  </div>
+
+                  {/* Visual Language Column */}
+                  <div className="flex flex-col min-h-0 md:min-h-[400px] xl:min-h-0">
+                    {vl && (
+                      <VisualLanguageForm
+                        vl={vl}
+                        onSuccess={setResults}
+                        onLoadingChange={(loading, abortFn) => {
+                          setVLFormLoading(loading, abortFn);
+                        }}
+                        onReset={resetVisuals}
+                        highlightRanges={dslHighlightRanges}
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Right Panel - Visualizations */}
+              <div className="flex flex-col w-full">
+                <VisualizationResults
+                  svgFormal={svgFormal}
+                  formalError={formalError}
+                  svgIntuitive={svgIntuitive}
+                  intuitiveError={intuitiveError}
+                  missingSVGEntities={missingSVGEntities}
+                  componentMappings={componentMappings}
+                  dslValue={vl || ''}
+                  mwpValue={initialMWP}
+                  onDSLRangeHighlight={setDslHighlightRanges}
+                  onMWPRangeHighlight={setMwpHighlightRanges}
+                  onComponentUpdate={handleComponentUpdate}
+                  onRegenerateAfterUpload={handleRegenerateAfterUpload}
+                  onAllFilesUploaded={clearMissingSVGEntities}
+                  isRegenerating={vlFormLoading}
+                  isUploadRegenerating={uploadGenerating}
+                />
+                
+                {/* Loading animation below the accordion during regeneration */}
+                {(vlFormLoading || uploadGenerating) && (
+                  <div className="mt-6 animate-in fade-in-0 duration-300">
+                    <GearLoading 
+                      message={uploadGenerating ? "Regenerating..." : "Regenerating..."} 
+                      onAbort={handleAbort}
+                      showAbortButton={true}
+                      size="medium"
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+      <Toaster/>
+    </>
+  );
+}
+
+export default App;


### PR DESCRIPTION
Keep generated visuals and visual language form visible during regeneration and display the loading animation below the visualization accordion.

---
<a href="https://cursor.com/background-agent?bcId=bc-5dda0ce4-8133-4d42-93e8-5783173dbe80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5dda0ce4-8133-4d42-93e8-5783173dbe80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

